### PR TITLE
Listen also on IPv6

### DIFF
--- a/configs/nginx/pi.conf.template
+++ b/configs/nginx/pi.conf.template
@@ -1,5 +1,6 @@
 server {
     listen $LISTEN_PORT;
+    listen [::]:$LISTEN_PORT;
     client_max_body_size $NGINX_MAX_UPLOAD;
     location / {
         include uwsgi_params;


### PR DESCRIPTION
This pull request sets nginx to listen both on IPv4 and IPv6. [::] is equivalent of 0.0.0.0, although it has to be enabled explicitly.