### PR TITLE
update psycopg2 not to use binary package

### DIFF
--- a/prebuildfs/opt/requirements.txt
+++ b/prebuildfs/opt/requirements.txt
@@ -1,4 +1,4 @@
 uWSGI==2.0.22
-psycopg2-binary==2.9.9
+psycopg2==2.9.9
 privacyIDEA==3.9
 supervisor==4.2.5


### PR DESCRIPTION
fix #93 