### PR TITLE
fix behavior for SUPERUSER_REALM default and fix typo for Postgres DB URIs

### DIFF
--- a/rootfs/opt/templates/pi-config.template
+++ b/rootfs/opt/templates/pi-config.template
@@ -2,9 +2,6 @@ import os
 import logging
 import sys
 
-# Define list delimiters (single and double quotes)
-delimiters = ['"', "'"]
-
 SECRET_KEY = os.environ.get('SECRET_KEY')
 if SECRET_KEY is None:
     print("SECRET_KEY not set! Refusing to start")
@@ -16,16 +13,7 @@ if PI_PEPPER is None:
     sys.exit(1)
 
 # The realm, where users are allowed to login as administrators
-SUPERUSER_REALM = os.environ.get('SUPERUSER_REALM', ['administrator'])
-# Strip surrounding quotes if present
-for delimiter in delimiters:
-    if SUPERUSER_REALM.startswith(delimiter) and SUPERUSER_REALM.endswith(delimiter):
-        SUPERUSER_REALM = SUPERUSER_REALM[1:-1]
-# Check if the variable is a string and convert it to a list if necessary
-if isinstance(SUPERUSER_REALM, str):
-    SUPERUSER_REALM = SUPERUSER_REALM.split(",")
-# Print the SUPERUSER_REALM variable
-# print(f"Super realm(s): {SUPERUSER_REALM}")
+SUPERUSER_REALM = os.environ.get('SUPERUSER_REALM','administrator').split(',')
 
 SQLALCHEMY_DATABASE_URI = "$SQLALCHEMY_DATABASE_URI"
 PI_ENCFILE = os.environ.get("PI_ENCFILE", "/data/privacyidea/keys/encfile")

--- a/rootfs/usr/local/bin/start_privacyidea.sh
+++ b/rootfs/usr/local/bin/start_privacyidea.sh
@@ -56,7 +56,7 @@ function generate_pi_config {
             check_and_set_defaults
 
             # Define the SQLAlchemy database URI using the necessary variables
-            export SQLALCHEMY_DATABASE_URI==${DB_VENDOR}+psycopg2://${DB_USER}:${encoded_password}@${DB_HOST}:${DB_PORT}/${DB_NAME}
+            export SQLALCHEMY_DATABASE_URI=${DB_VENDOR}+psycopg2://${DB_USER}:${encoded_password}@${DB_HOST}:${DB_PORT}/${DB_NAME}
             ;;
 
         *)


### PR DESCRIPTION
Now without setting the SUPERUSER_REALM environment variable, the container shall run again.

Additionally a typo in the SQLALCHEMY_DATABASE_URI when using a postgres db is fixed.

fixes #108