### PR TITLE
add libpq5 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV PI_SKIP_BOOTSTRAP=false \
 
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN install_packages ca-certificates gettext-base tini tree jq && \
+RUN install_packages ca-certificates gettext-base tini tree jq libpq5 && \
     mkdir -p "$PI_DATA_DIR" "$PI_CFG_DIR" && \
     chown -R nobody:nogroup "$PI_DATA_DIR" "$PI_CFG_DIR"
 USER nobody


### PR DESCRIPTION
Currently, `libpq` is missing in the final image, which prevents PrivacyIDEA from starting up when using PostgreSQL as a database connection. Adding `libpq` to the `install_packages` arguments resolves the issue.