### PR TITLE
Update Dockerfile - added curl for basic healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE_TAG=3.8.18-slim-bookworm
 FROM python:$BASE_IMAGE_TAG as builder
 ENV VIRTUAL_ENV=/opt/privacyidea
 WORKDIR $VIRTUAL_ENV
-RUN apt-get update && apt-get install -y python3-dev gcc libpq-dev libkrb5-dev
+RUN apt-get update && apt-get install -y python3-dev gcc libpq-dev libkrb5-dev curl
 COPY requirements.txt requirements.txt
 RUN python3 -m venv "$VIRTUAL_ENV" && . $VIRTUAL_ENV/bin/activate && pip3 install wheel && pip3 install -r requirements.txt
 


### PR DESCRIPTION
Hi,

added curl for basic docker healthcheck

eg:

```
    healthcheck:
      test: ['CMD', 'curl --fail http://127.0.0.1:8080 || exit 1']
      interval: 15s
      timeout: 15s
      retries: 4
      start_period: 60s
```

BR
Takalele