### PR TITLE
Automatic DB upgrade(Experimental) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The Khalibre privacyIDEA container can create a default admin user by setting th
 | `PI_DB_HOST` | Database host. For on postgres use it support multiple hosts with comma separated | |
 | `PI_DB_PORT` | Database port. For on postgres use it support multiple hosts with comma separated | depnds on PI_DB_VENDOR default for each type |
 | `PI_DB_ARGS` | Addiitional DB attributes | |
+| `PI_DB_UPGRADE` | Automatic DB Migration after versiion upgrade. **Experimental**, not for production use. To enable se to TRUE value(case sensetive) | |
+ | `PI_BACKUP_DIR` | For use together with PI_DB_UPGRADE -- backup directory path, don't forget to mount persistant volume | /mnt/files/backups |
 | `SQLALCHEMY_DATABASE_URI` | Full SQL connection string. If set it will override all PI_DB_* settings | |
 | `PI_CACHE_TYPE` | privacyIDEA cache type | simple |
 | `PI_PEPPER` | This is used to encrypt the admin passwords | |

--- a/rootfs/usr/local/bin/configure_privacyidea.sh
+++ b/rootfs/usr/local/bin/configure_privacyidea.sh
@@ -122,6 +122,19 @@ function prestart_privacyidea {
         echo ""
     fi
 
+    # Check if DB update is needed and perform backup and upgrade
+    if [ "$PI_DB_UPGRADE" = "TRUE" ]; then
+        PI_MIGRATION_DIR="/opt/privacyidea/lib/privacyidea/migrations"
+        CUR_REV=$(/opt/privacyidea/bin/pi-manage db heads -d $PI_MIGRATION_DIR 2>/dev/null | cut -f1 -d ' ')
+        if [[ "$CUR_REV" != $(/opt/privacyidea/bin/pi-manage db current -d $PI_MIGRATION_DIR 2>/dev/null | tail -1) ]]; then
+            if [ -z "PI_BACKUP_PATH" ] && [ ! -d /mnt/files/backups]; then
+                mkdir /mnt/files/backups
+            fi
+            /opt/privacyidea/bin/pi-manage backup create -d ${PI_BACKUP_PATH:-"/mnt/files/backups/"}
+            /opt/privacyidea/bin/pi-manage db upgrade $CUR_REV -d $PI_MIGRATION_DIR
+        fi
+    fi
+
     # Execute scripts from mounted directory
     if [ -d "${PI_MOUNT_DIR}/scripts" ]; then
         execute_scripts "${PI_MOUNT_DIR}/scripts"


### PR DESCRIPTION
Add first revision of automatic DB migration if application version is upgraded
**To-Do**:

- [ ]  automatic downgrade
- [ ] check if persistent volume is mount for backup or disable automatic upgrade otherwise 
- [ ] need to be reviewed