### PR TITLE
Fix typo in README Registry section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The docker image is a self-contained Debian with privacyIDEA installed, which wi
 
 ### Registry
 
-The image is stored in bellow registries:
+The image is stored in below registries:
 
 - [Docker Hub](https://hub.docker.com/r/kheeklab/privacyidea)
 - [GitHub Container Registry](https://github.com/kheeklab/privacyidea-docker/pkgs/container/privacyidea)


### PR DESCRIPTION
### Motivation
- Fix a spelling mistake in the `Registry` section of the project's README to improve documentation clarity.
- Ensure the sentence reads correctly without altering any other wording.

### Description
- Replace the phrase "bellow registries" with "below registries" in `README.md`.
- Only that single sentence was modified and no other content was changed.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b5c45386c83229ff6a09de10dc789)