### PR TITLE
Avoid literal glob expansion in execute_scripts

### DIFF
--- a/rootfs/usr/local/bin/_privacyidea_common.sh
+++ b/rootfs/usr/local/bin/_privacyidea_common.sh
@@ -4,7 +4,8 @@ execute_scripts() {
   local script_dir="$1"
   local script_names
 
-  if [[ -d "$script_dir" ]] && script_names=("$script_dir"/*.sh); (( ${#script_names[@]} )); then
+  if [[ -d "$script_dir" ]] && compgen -G "${script_dir}/*.sh" > /dev/null; then
+    script_names=("$script_dir"/*.sh)
     echo "[PrivacyIDEA] Executing scripts in $script_dir:"
 
     for script_path in "${script_names[@]}"; do


### PR DESCRIPTION
### Motivation
- Prevent accidental execution of a literal glob pattern when a directory contains no `.sh` files.
- Ensure `execute_scripts` is a no-op when no scripts are present in the target directory.
- Use a robust check for matching files before iterating to avoid surprising behavior.

### Description
- In `rootfs/usr/local/bin/_privacyidea_common.sh`, updated `execute_scripts` to use `compgen -G "${script_dir}/*.sh" > /dev/null` to detect matching `.sh` files.
- Assign `script_names=("$script_dir"/*.sh)` only after `compgen` confirms matches to avoid literal-glob iteration.
- Retain original behavior of echoing and `source`-ing each script and returning non-zero on script failure.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b5c896ca883229ef94830212578c5)