### PR TITLE
Fix README privacyidea scripts path

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ All of the use cases can be triggered on container creation when the container f
 ### Key Container Folders
 
 - /mnt/privacyidea
-- /user/local/privacyidea/scripts
+- /usr/local/privacyidea/scripts
 
 The Container Lifecycle and API specifies the scanned subfolders, the phases in which the container scans them, and the actions taken on their files.
 
@@ -189,7 +189,7 @@ After you create a container in an environment, the container entry point execut
 The container entry point scans the following container folders for files and uses those files to configure the container and privacyIDEA and to act on privacyIDEA.
 
 - /mnt/privacyidea
-- /user/local/privacyidea/scripts
+- /usr/local/privacyidea/scripts
 
 The key folders above have subfolders that are designated for specific actions. The subfolders, the actions taken on their files, and associated use cases are listed in lifecycle phase order in the following sections.
 


### PR DESCRIPTION
### Motivation

- Align documentation with the container entrypoint and runtime directory used at runtime.
- Correct incorrect references to the scripts folder from `/user/local/privacyidea/scripts` to `/usr/local/privacyidea/scripts`.
- Ensure the `Key Container Folders` and `API` sections consistently document the runtime paths.

### Description

- Updated `README.md` to replace `/user/local/privacyidea/scripts` with `/usr/local/privacyidea/scripts`.
- Changes apply to the `Key Container Folders` and `Container Lifecycle and API` sections.
- Two occurrences in `README.md` were updated.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b5d0d8b788322a3bf6213bb6ab714)