### PR TITLE
Update Dockerfile - added curl for basic healthcheck (again - PR-144)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV PI_SKIP_BOOTSTRAP=false \
 
 COPY prebuildfs /
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN install_packages ca-certificates gettext-base tini tree jq libpq5 && \
+RUN install_packages ca-certificates gettext-base tini tree jq libpq5 curl && \
     mkdir -p "$PI_DATA_DIR" "$PI_CFG_DIR" /var/log/privacyidea && \
     chown -R nobody:nogroup "$PI_DATA_DIR" "$PI_CFG_DIR" /var/log/privacyidea
 USER nobody


### PR DESCRIPTION
somehow curl was not in the final image anymore, now its back and the healthcheck is working again.

```
    healthcheck:
      test: ['CMD', 'curl --fail http://127.0.0.1:8080 || exit 1']
      interval: 15s
      timeout: 15s
      retries: 4
      start_period: 60s
```